### PR TITLE
MSPA-917 Added ref support for s3 lifecycle expiry days.

### DIFF
--- a/examples/S3_Bucket_With_Lifecycle_Rules_Ref.py
+++ b/examples/S3_Bucket_With_Lifecycle_Rules_Ref.py
@@ -1,0 +1,47 @@
+# Converted from S3_Bucket.template located at:
+# http://aws.amazon.com/cloudformation/aws-cloudformation-templates/
+
+from troposphere import Output, Parameter, Ref, Template
+from troposphere.s3 import Bucket, PublicRead, \
+    LifecycleConfiguration, LifecycleRule
+
+t = Template()
+
+t.set_description(
+    "AWS CloudFormation Sample Template S3_Bucket: Sample template showing :"
+    "How to create a publicly accessible S3 bucket. "
+    "How to set a lifecycle rule using a Ref. "
+    "**WARNING** This template creates an Amazon S3 Bucket. "
+    "You will be billed for the AWS resources used if you create "
+    "a stack from this template.")
+
+lifecycleDays = t.add_parameter(Parameter("LifecycleRuleDaysRef",
+                                Type="Number", Default=3))
+
+s3bucket = t.add_resource(Bucket(
+    "S3Bucket",
+    # Make public Read
+    AccessControl=PublicRead,
+    # Turn on Versioning to the whole S3 Bucket
+    # Attach a LifeCycle Configuration
+
+    LifecycleConfiguration=LifecycleConfiguration(Rules=[
+        # Add a rule to
+        LifecycleRule(
+            # Rule attributes
+            Id="S3BucketRule001",
+            Prefix="/only-this-sub-dir",
+            Status="Enabled",
+            # use a reference rather than a literal
+            ExpirationInDays=Ref(lifecycleDays)
+        )
+    ])
+))
+
+t.add_output(Output(
+    "BucketName",
+    Value=Ref(s3bucket),
+    Description="Name of S3 bucket to hold website content"
+))
+
+print(t.to_json())

--- a/tests/examples_output/S3_Bucket_With_Lifecycle_Rules_Ref.template
+++ b/tests/examples_output/S3_Bucket_With_Lifecycle_Rules_Ref.template
@@ -1,0 +1,37 @@
+{
+    "Description": "AWS CloudFormation Sample Template S3_Bucket: Sample template showing :How to create a publicly accessible S3 bucket. How to set a lifecycle rule using a Ref. **WARNING** This template creates an Amazon S3 Bucket. You will be billed for the AWS resources used if you create a stack from this template.",
+    "Outputs": {
+        "BucketName": {
+            "Description": "Name of S3 bucket to hold website content",
+            "Value": {
+                "Ref": "S3Bucket"
+            }
+        }
+    },
+    "Parameters": {
+        "LifecycleRuleDaysRef": {
+            "Default": 3,
+            "Type": "Number"
+        }
+    },
+    "Resources": {
+        "S3Bucket": {
+            "Properties": {
+                "AccessControl": "PublicRead",
+                "LifecycleConfiguration": {
+                    "Rules": [
+                        {
+                            "ExpirationInDays": {
+                                "Ref": "LifecycleRuleDaysRef"
+                            },
+                            "Id": "S3BucketRule001",
+                            "Prefix": "/only-this-sub-dir",
+                            "Status": "Enabled"
+                        }
+                    ]
+                }
+            },
+            "Type": "AWS::S3::Bucket"
+        }
+    }
+}

--- a/troposphere/s3.py
+++ b/troposphere/s3.py
@@ -7,6 +7,7 @@ import warnings
 from . import AWSHelperFn, AWSObject, AWSProperty, Tags
 from .compat import policytypes
 from .validators import boolean, integer, positive_integer, s3_bucket_name
+from .validators import positive_integer_or_reference
 from .validators import s3_transfer_acceleration_status
 
 Private = "Private"
@@ -120,7 +121,7 @@ class LifecycleRule(AWSProperty):
         'AbortIncompleteMultipartUpload':
             (AbortIncompleteMultipartUpload, False),
         'ExpirationDate': (basestring, False),
-        'ExpirationInDays': (positive_integer, False),
+        'ExpirationInDays': (positive_integer_or_reference, False),
         'Id': (basestring, False),
         'NoncurrentVersionExpirationInDays': (positive_integer, False),
         'NoncurrentVersionTransition': (NoncurrentVersionTransition, False),

--- a/troposphere/validators.py
+++ b/troposphere/validators.py
@@ -40,6 +40,12 @@ def positive_integer(x):
     return x
 
 
+def positive_integer_or_reference(x):
+    if isinstance(x, basestring):
+        return x
+    return positive_integer(x)
+
+
 def integer_range(minimum_val, maximum_val):
     def integer_range_checker(x):
         i = int(x)


### PR DESCRIPTION
S3 Lifecycle ExpirationInDays can now be a literal number or a reference.

I've added a new validator 'positive-integer-or-reference()' and changed the property to use that validator.

There's also an example and an expected output file for testing.